### PR TITLE
Hints in prod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 # Build and test
-build :; nile compile
+build :; nile compile --disable-hint-validation
 test  :; pytest tests/

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 # Build and test
-build :; nile compile --disable-hint-validation
+build :; nile compile 
 test  :; pytest tests/

--- a/contracts/uint384_contract.cairo
+++ b/contracts/uint384_contract.cairo
@@ -118,7 +118,7 @@ end
 func uint384_and{bitwise_ptr : BitwiseBuiltin*, range_check_ptr}(a : Uint384, b : Uint384) -> (
     res : Uint384
 ):
-    let (res) = uint384_lib.and(a, b)
+    let (res) = uint384_lib.uint384_and(a, b)
     return (res)
 end
 
@@ -162,5 +162,15 @@ func uint384_reverse_endian{bitwise_ptr : BitwiseBuiltin*, range_check_ptr}(num 
     res : Uint384
 ):
     let (res) = uint384_lib.reverse_endian(num)
+    return (res)
+end
+
+
+# Returns the negation of an integer.
+@view
+func uint384_neg{bitwise_ptr : BitwiseBuiltin*, range_check_ptr}(num : Uint384) -> (
+    res : Uint384
+):
+    let (res) = uint384_lib.neg(num)
     return (res)
 end

--- a/contracts/uint384_contract.cairo
+++ b/contracts/uint384_contract.cairo
@@ -118,7 +118,7 @@ end
 func uint384_and{bitwise_ptr : BitwiseBuiltin*, range_check_ptr}(a : Uint384, b : Uint384) -> (
     res : Uint384
 ):
-    let (res) = uint384_lib.uint384_and(a, b)
+    let (res) = uint384_lib.bit_and(a, b)
     return (res)
 end
 

--- a/lib/uint384.cairo
+++ b/lib/uint384.cairo
@@ -123,12 +123,12 @@ namespace uint384_lib:
 
         %{
             from starkware.python.math_utils import isqrt
-            
+
             def split(num: int, num_bits_shift: int, length: int):
                 a = []
                 for _ in range(length):
                     a.append( num & ((1 << num_bits_shift) - 1) )
-                    num = num >> num_bits_shift 
+                    num = num >> num_bits_shift
                 return tuple(a)
 
             def pack(z, num_bits_shift: int) -> int:
@@ -248,13 +248,13 @@ namespace uint384_lib:
                 a = []
                 for _ in range(length):
                     a.append( num & ((1 << num_bits_shift) - 1) )
-                    num = num >> num_bits_shift 
+                    num = num >> num_bits_shift
                 return tuple(a)
 
             def pack(z, num_bits_shift: int) -> int:
                 limbs = (z.d0, z.d1, z.d2)
                 return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
-                
+
             a = pack(ids.a, num_bits_shift = 128)
             div = pack(ids.div, num_bits_shift = 128)
             quotient, remainder = divmod(a, div)
@@ -383,7 +383,7 @@ namespace uint384_lib:
     end
 
     # Computes the bitwise AND of 2 uint256 integers.
-    func and{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(a : Uint384, b : Uint384) -> (
+    func uint384_and{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(a : Uint384, b : Uint384) -> (
         res : Uint384
     ):
         let (d0) = bitwise_and(a.d0, b.d0)

--- a/lib/uint384.cairo
+++ b/lib/uint384.cairo
@@ -383,7 +383,7 @@ namespace uint384_lib:
     end
 
     # Computes the bitwise AND of 2 uint256 integers.
-    func uint384_and{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(a : Uint384, b : Uint384) -> (
+    func bit_and{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(a : Uint384, b : Uint384) -> (
         res : Uint384
     ):
         let (d0) = bitwise_and(a.d0, b.d0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,9 +26,9 @@ async def starknet_factory():
 async def uint384_contract(starknet_factory):
     starknet = starknet_factory
     # Deploy the account contract
-    contract_def = compile_starknet_files(
+    contract_class = compile_starknet_files(
         files=[UINT384_CONTRACT], disable_hint_validation=True
     )
-    contract = await starknet.deploy(contract_def=contract_def)
+    contract = await starknet.deploy(contract_class=contract_class)
     return contract
 


### PR DESCRIPTION
Hints are whitelisted so let's modify the ones that are a little bit off of the [starknet whitelist] so we can compile the contract (https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/starknet/security/whitelists/384_bit_prime_field.json)

To test compilation run `make build`